### PR TITLE
PEN-1117: Automatic deployments to ALC

### DIFF
--- a/cfn/configs/deployment.yml
+++ b/cfn/configs/deployment.yml
@@ -9,7 +9,7 @@ context:
 
     git:
       owner: WPMedia
-      branch: staging
+      branch: master
       repo: news-theme-css
 
     stages:

--- a/cfn/configs/deployment.yml
+++ b/cfn/configs/deployment.yml
@@ -1,0 +1,28 @@
+template: v1/cfn/shared/pipelines/simple-pipeline/simple-pipeline.template.yml
+stack_name: news-theme-css-inf-pipeline
+region: us-east-1
+
+context:
+  pipeline:
+    name: news-theme-css-inf
+    restart_on_update: true
+
+    git:
+      owner: WPMedia
+      branch: staging
+      repo: news-theme-css
+
+    stages:
+      - name: Pipeline
+        actions:
+          - name: RebuildThisPipeline
+            config: cfn/configs/deployment.yml
+
+      - name: Package-and-Deploy
+        actions:
+          - name: Package-and-Deploy
+            image: aws/codebuild/standard:2.0
+            buildspec: codebuild/buildspec.yml
+            outputArtifact: ServerlessPackage
+            env_vars:
+              phase: Package

--- a/codebuild/buildspec.yml
+++ b/codebuild/buildspec.yml
@@ -15,9 +15,8 @@ phases:
     commands:
       - echo Build finished on `date`
       - echo Deployment started on `date`
-      - aws s3 rm s3://arc-learning-center-static/docs/styleguides/news-theme-css --recursive
       - echo Syncing files...
-      - aws s3 sync styleguide s3://arc-learning-center-static/docs/styleguides/news-theme-css --cache-control max-age=31536000
+      - aws s3 sync styleguide s3://arc-learning-center-static/docs/styleguides/news-theme-css --acl public-read --cache-control max-age=31536000
 
 artifacts:
   files:

--- a/codebuild/buildspec.yml
+++ b/codebuild/buildspec.yml
@@ -1,0 +1,26 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 10
+    commands:
+      - echo Running npm install...
+      - npm install
+  build:
+    commands:
+      - echo Build started on `date`
+      - npm run build-all
+  post_build:
+    commands:
+      - echo Build finished on `date`
+      - echo Deployment started on `date`
+      - aws s3 rm s3://arc-learning-center-static/docs/styleguides/news-theme-css --recursive
+      - echo Syncing files...
+      - aws s3 sync styleguide s3://arc-learning-center-static/docs/styleguides/news-theme-css --cache-control max-age=31536000
+
+artifacts:
+  files:
+    - styleguide/**/*
+    - css/**
+    - styleguide.css

--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,6 @@ open styleguide/index.html
 6. In the root package.json file of the blocks repo, update 
 @wpmedia/news-theme-css to the new version then run in the block repo
 the following commands: `npx lerna clean` and then `npx lerna bootstrap`
+
+### Deploy to Arc Learning Center
+News theme CSS automatically deploys to ALC. You can find the live version [here](https://staging.arcpublishing.com/alc/docs/styleguides/news-theme-css)


### PR DESCRIPTION
- Set up automatic deployments for news theme css
- Every commit on `master` will trigger an automated deployment to ALC's S3 bucket
- [Jira ticket](https://arcpublishing.atlassian.net/secure/RapidBoard.jspa?rapidView=545&modal=detail&selectedIssue=PEN-1117)