### PR TITLE
PEN-1137: News Theme CSS public

### DIFF
--- a/LICENSE.MD
+++ b/LICENSE.MD
@@ -1,0 +1,10 @@
+Shield: [![CC BY-NC-ND 4.0][cc-by-shield]][cc-by-nc-nd]
+
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License][cc-by-nc-nd].
+
+[![CC BY-NC-ND 4.0][cc-by-image]][cc-by-nc-nd]
+
+[cc-by-nc-nd]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+[cc-by-image]: https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.10",
   "description": "CSS Grid Framework with Bootstrap-like conventions",
   "author": "Brent Miller",
-  "license": "ISC",
+  "license": "CC-BY-NC-ND-4.0",
   "main": "scss/index.scss",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -15,7 +15,7 @@
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
-    "access": "restricted"
+    "access": "public"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -47,3 +47,16 @@ the following commands: `npx lerna clean` and then `npx lerna bootstrap`
 
 ### Deploy to Arc Learning Center
 News theme CSS automatically deploys to ALC. You can find the live version [here](https://staging.arcpublishing.com/alc/docs/styleguides/news-theme-css)
+
+## License
+
+Shield: [![CC BY-NC-ND 4.0][cc-by-shield]][cc-by-nc-nd]
+
+This work is licensed under a
+[Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License][cc-by-nc-nd].
+
+[![CC BY-NC-ND 4.0][cc-by-image]][cc-by-nc-nd]
+
+[cc-by-nc-nd]: https://creativecommons.org/licenses/by-nc-nd/4.0/
+[cc-by-image]: https://licensebuttons.net/l/by-nc-nd/3.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY--NC--ND%204.0-lightgrey.svg


### PR DESCRIPTION
- Added licenses to make News Theme's repo public
- Same process as https://github.com/WPMedia/fusion-news-theme-blocks/pull/411