### PR TITLE
PEN-1241 - remove spacing below images

### DIFF
--- a/scss/_links.scss
+++ b/scss/_links.scss
@@ -24,3 +24,7 @@ a picture {
     opacity: 0.7;
   }
 }
+
+a picture img {
+  vertical-align: middle;
+}

--- a/scss/_links.scss
+++ b/scss/_links.scss
@@ -25,6 +25,6 @@ a picture {
   }
 }
 
-a picture img {
+a > picture > img {
   vertical-align: middle;
 }


### PR DESCRIPTION
[PEN-1241](https://arcpublishing.atlassian.net/browse/PEN-1241)

Was tested on different pages on different breakpoints without issues. 
But I'm a bit concerned about the broad of the selector used.

One solution could be to use a class per block
```
.card-list-container {
  a > picture > image {
     .....
  }
}
.top-table-list-container {
  a > picture > image {
     .....
  }
}
```
__cons__: touch all blocks - new blocks must remember to add this class
__pro__: user generated blocks that have the same layout do not get the definition


Other idea is to add a new class to identify all the Arc blocks and use a generic selector.
```
.arc-block {
  a > picture > image {
     .....
  }
}
```
__cons__: touch all the blocks
__pro__: new blocks get the functionality
user generated blocks that have the same layout do not get the definition


# Before
added this style to the images to show the padding
```
a > picture {
    background-color: red
}
```
![2020_0817_170331](https://user-images.githubusercontent.com/9757/90441466-6238a700-e0af-11ea-9dcf-a1367bd7aefa.png)
![2020_0817_171737](https://user-images.githubusercontent.com/9757/90441487-6a90e200-e0af-11ea-8863-c746c3f28398.png)

# After

![2020_0817_173241](https://user-images.githubusercontent.com/9757/90441652-b5125e80-e0af-11ea-99b9-d32efe9873e3.png)
![2020_0817_171749](https://user-images.githubusercontent.com/9757/90441511-72508680-e0af-11ea-96f6-7ddfe507821c.png)


