### PR TITLE
Update deployment pipeline to use stable branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Description
+_Information about what you changed for this PR_
+
+## Jira Ticket
+- [PEN-](https://arcpublishing.atlassian.net/browse/PEN-)
+
+## Acceptance Criteria
+_copy from ticket_
+
+## Test Steps
+- Add test steps a reviewer must complete to test this PR
+
+## Effect Of Changes
+### Before
+_Example: When I clicked the search button, the button turned red._
+
+[include screenshot or gif or link to video, storybook would be awesome]
+
+### After
+_Example: When I clicked the search button, the button turned green._
+
+[include screenshot or gif or link to video, storybook would be awesome]
+
+## Dependencies or Side Effects
+_Examples of dependencies or side effects are:_
+- Additional settings that will be required in the blocks.json
+- Changes to the custom fields which will require users to reconfigure features
+- Update to css framework or SDK
+- Dependency on another PR that needs to be merged first
+
+## Review Checklist
+_The author of the PR should fill out the following sections to ensure this PR is ready for review._
+- [ ] Confirmed all the test steps above are working
+- [ ] Confirmed there are no linter errors
+- [ ] Confirmed this PR has reasonable code coverage
+  - [ ] Confirmed this PR has unit test files
+  - [ ] Ran `npm test`, made sure all tests are passing
+  - [ ] If the amount of work to write unit tests for this change are excessive,
+please explain why (so that we can fix it whenever it gets refactored).
+- [ ] Confirmed relevant documentation has been updated/added.

--- a/cfn/configs/deployment.yml
+++ b/cfn/configs/deployment.yml
@@ -9,7 +9,7 @@ context:
 
     git:
       owner: WPMedia
-      branch: master
+      branch: stable
       repo: news-theme-css
 
     stages:


### PR DESCRIPTION
Per the requirements of [PEN-1265](https://arcpublishing.atlassian.net/browse/PEN-1265), the deployment should be based off the of the `stable` branch as the `master` branch will be deprecated for standardization.