### PR TITLE
Block spacing updates (WIP)

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -14,6 +14,22 @@
   }
 }
 
+// this needs to be documented if added
+// @mixin block-internal-spacing
+//
+// this mixin controls the internal spacing of items in a block
+
+@mixin block-internal-spacing {
+  margin-bottom: map-get($spacers, 'sm');
+
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')){
+    margin-bottom: map-get($spacers, 'sm');
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
 
 // @mixin link-color-active-hover
 //
@@ -67,11 +83,9 @@
 //
 // Mixin to add style to the HR element used as separator
 //
-@mixin container-hr-separator {
-  > hr {
-    background-color: $border-rule-color; // $ui-light-gray;
-    border: 0;
-    height: 1px;
-    margin-top: 0;
-  }
+hr {
+  background-color: $border-rule-color; // $ui-light-gray;
+  border: 0;
+  height: 1px;
+  margin-top: 0;
 }

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -51,7 +51,7 @@
 // 
 // Mixin to add vertical spaing to the elements in a container block
 //
-@mixin container-vertial-spacing {
+@mixin container-vertical-spacing {
   > * {
     margin-bottom: map-get($spacers, 'lg');
   }

--- a/scss/components/_chain_spacing.scss
+++ b/scss/components/_chain_spacing.scss
@@ -1,12 +1,12 @@
 .chain-container {
   .chain-col {
-    @include container-vertial-spacing;
+    @include container-vertical-spacing;
     @include container-hr-separator;
   }
 }
 
 .layout-section {
-  @include container-vertial-spacing;
+  @include container-vertical-spacing;
   @include container-hr-separator;
 }
 

--- a/scss/components/_chain_spacing.scss
+++ b/scss/components/_chain_spacing.scss
@@ -1,13 +1,11 @@
 .chain-container {
   .chain-col {
     @include container-vertical-spacing;
-    @include container-hr-separator;
   }
 }
 
 .layout-section {
   @include container-vertical-spacing;
-  @include container-hr-separator;
 }
 
 // Used to remove the extra margin on layouts when the class


### PR DESCRIPTION
## Description
This PR includes a new mix-in to help with internal block spacing, as well as cleaning up `<hr>` elements

## New Mix-in proposal for handling internal block spacing
The new spacing updates flowed into the individual blocks themselves. In the screenshot below, the **Simple List Arc Block** has a class `.layout-section` on it that adds spacing values meant for the layout containers.

![image](https://user-images.githubusercontent.com/1590723/97460634-51a87680-1913-11eb-989d-a1920abfa79d.png)

I recommend we create an additional mix-in and separate layout spacing and internal block spacing (which naturally by design we want to be smaller/tighter spacing than the layout rules)

## Can we make `<hr>` a global element?
In the example below the **Simple List Arc Block** has the `@mixin container-hr-separator` applied to it. There is no instance in the design use case where we would want an `<hr>` element to be styled differently. I would rather scope the styles to the global element so there is less lift when using `<hr>` elements in custom blocks.

![image](https://user-images.githubusercontent.com/1590723/97460889-8e746d80-1913-11eb-8844-c072078d647c.png)

## Effects on Arc Blocks
Some arc blocks will need to be refactored to use the new mixin/hr styles. I will be handling those changes in a PR in that repo in the next day or two.