### PR TITLE
Adding warning note to homepage docs

### DIFF
--- a/kss-config.json
+++ b/kss-config.json
@@ -3,6 +3,7 @@
   "source": [
     "scss/"
   ],
+  "homepage": "./scss/homepage.md",
   "destination": "styleguide/",
   "builder": "michelangelo/kss_styleguide/custom-template/",
   "css": [

--- a/scss/homepage.md
+++ b/scss/homepage.md
@@ -6,10 +6,16 @@ This is the CSS framework for the Fusion News Theme that provides the foundation
 - Typography
 - Breakpoints and spacing
 - Utility Sass functions (i.e. convert px to rems, etc.)
-- A JavaScript package that has versions of some of the Sass functions (i.e. `calculateRem`, `lightenDarkenColor` ) as well as an object 
-(`framework`) that holds properties for spacing, breakpoints, etc. The `js/framework.js` file is useful when you need to tap 
-into some of the functionality and properties of the framework when working in JavaScript. 
+- A JavaScript package that has versions of some of the Sass functions (i.e. `calculateRem`, `lightenDarkenColor` ) as well as an object
+(`framework`) that holds properties for spacing, breakpoints, etc. The `js/framework.js` file is useful when you need to tap
+into some of the functionality and properties of the framework when working in JavaScript.
 The JavaScript package also has a set of styled components (`js/styled/linkHovers.js`) that are used to set hover styles.
+
+---
+> ***Note of Caution***
+>
+> While it is possible to override the styling provided by this CSS framework or the individual Themes components by applying more specific selectors, this is not recommended. Because the CSS framework and Themes components are subject to change, it is possible that CSS selector overrides will break as elements, class names, IDs and other references change within these components. If you require custom styling of a component, we recommend writing a custom component to handle your needs. If you are currently overriding any styling on the Themes website, we invite you to submit your use case to the [Themes Ideas Board](https://ideas.arcpublishing.com/) so it can be considered as a future roadmap item.
+---
 
 ### Getting Started:
 To use Theme CSS within a feature pack repository, it must be configured through a file in the root of the repo called `blocks.json`. This is a file that Fusion (Hydrate versions) knows to
@@ -84,33 +90,34 @@ Here is an example of what a the CSS setup in the `block.json` might look like.
   }
 }
 ```
+
 ### Custom Block Developers
-If you are creating custom blocks for your site and plan on using news-theme-css as a dependency, 
+If you are creating custom blocks for your site and plan on using news-theme-css as a dependency,
 then in addition to configuring blocks.json as per the section above, you will need to follow some additional
 steps to ensure this framework is available in your code.  There are two different scenarios in custom development
 that pertain to using this framework:  Developing custom components in a feature pack and developing custom
-components in a separate repository. 
+components in a separate repository.
 
 #### Developing custom components in a feature pack
-If you are developing your custom components directly in your feature pack, then as long as you have set 
+If you are developing your custom components directly in your feature pack, then as long as you have set
 up your blocks.json to use the CSS Framework, you do not explicitly add the framework to any
-package.json file or directly import the framework's sass files into your component's sass file.  Fusion takes 
+package.json file or directly import the framework's sass files into your component's sass file.  Fusion takes
 care of properly importing the CSS Framework into component's sass file as well as setting theme values.  However.
-if you require any of the functionality from the framework's JavaScript assets, then you will need to 
+if you require any of the functionality from the framework's JavaScript assets, then you will need to
 import that into your component's JavaScript.  For example, if you needed the `framework` object, you would
 import that in your JS or JSX file like this: `import { framework } from '@wpmedia/news-theme-css/js/framework';`
 
 #### Developing custom components in a separate repository
-If you are developing your custom components in a separate repository, then as long as you have set 
-up your blocks.json to use the css framework in the feature pack that will leverage your component repository, 
-you still do not need to directly import the framework's sass files 
-into your component's sass file.  However, you will need to add the CSS Framework as a dependency to your external 
-component's package.json file. 
+If you are developing your custom components in a separate repository, then as long as you have set
+up your blocks.json to use the css framework in the feature pack that will leverage your component repository,
+you still do not need to directly import the framework's sass files
+into your component's sass file.  However, you will need to add the CSS Framework as a dependency to your external
+component's package.json file.
 
-Note: When adding the dependency to package.json, ensure that it is the same version 
-that you specify for `cssFramework` in blocks.json. 
+Note: When adding the dependency to package.json, ensure that it is the same version
+that you specify for `cssFramework` in blocks.json.
 
-If you require any of the functionality from the framework's 
-JavaScript assets, then you will need to import that into your component's JavaScript.  
+If you require any of the functionality from the framework's
+JavaScript assets, then you will need to import that into your component's JavaScript.
 For example, if you needed the `framework` object, you would
 import that in your JS or JSX file like this: `import { framework } from '@wpmedia/news-theme-css/js/framework';`

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -246,6 +246,12 @@
 into some of the functionality and properties of the framework when working in JavaScript.
 The JavaScript package also has a set of styled components (<code>js/styled/linkHovers.js</code>) that are used to set hover styles.</li>
 </ul>
+<hr>
+<blockquote>
+<p><em><strong>Note of Caution</strong></em></p>
+<p>While it is possible to override the styling provided by this CSS framework or the individual Themes components by applying more specific selectors, this is not recommended. Because the CSS framework and Themes components are subject to change, it is possible that CSS selector overrides will break as elements, class names, IDs and other references change within these components. If you require custom styling of a component, we recommend writing a custom component to handle your needs. If you are currently overriding any styling on the Themes website, we invite you to submit your use case to the <a href="https://ideas.arcpublishing.com/">Themes Ideas Board</a> so it can be considered as a future roadmap item.</p>
+</blockquote>
+<hr>
 <h3>Getting Started:</h3>
 <p>To use Theme CSS within a feature pack repository, it must be configured through a file in the root of the repo called <code>blocks.json</code>. This is a file that Fusion (Hydrate versions) knows to
 look for and run specific internal build commands to bring everything
@@ -359,7 +365,7 @@ component's package.json file.</p>
 <p>Note: When adding the dependency to package.json, ensure that it is the same version
 that you specify for <code>cssFramework</code> in blocks.json.</p>
 <p>If you require any of the functionality from the framework's
-JavaScript assets, then you will need to import that into your component's JavaScript.<br>
+JavaScript assets, then you will need to import that into your component's JavaScript.
 For example, if you needed the <code>framework</code> object, you would
 import that in your JS or JSX file like this: <code>import { framework } from '@wpmedia/news-theme-css/js/framework';</code></p>
 

--- a/styleguide/item-1-1-1.html
+++ b/styleguide/item-1-1-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>17</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>17</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-1">

--- a/styleguide/item-1-1-10.html
+++ b/styleguide/item-1-1-10.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-10">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>83</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>83</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-10">

--- a/styleguide/item-1-1-2.html
+++ b/styleguide/item-1-1-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>25</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>25</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-2">

--- a/styleguide/item-1-1-3.html
+++ b/styleguide/item-1-1-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>34</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>34</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-3">

--- a/styleguide/item-1-1-4.html
+++ b/styleguide/item-1-1-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>41</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>41</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-4">

--- a/styleguide/item-1-1-5.html
+++ b/styleguide/item-1-1-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>48</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>48</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-5">

--- a/styleguide/item-1-1-6.html
+++ b/styleguide/item-1-1-6.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>55</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>55</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-6">

--- a/styleguide/item-1-1-7.html
+++ b/styleguide/item-1-1-7.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>62</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>62</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-7">

--- a/styleguide/item-1-1-8.html
+++ b/styleguide/item-1-1-8.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>69</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>69</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-8">

--- a/styleguide/item-1-1-9.html
+++ b/styleguide/item-1-1-9.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>76</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>76</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-9">

--- a/styleguide/item-1-1.html
+++ b/styleguide/item-1-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1">

--- a/styleguide/item-1-2-1.html
+++ b/styleguide/item-1-2-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-1">

--- a/styleguide/item-1-2-2.html
+++ b/styleguide/item-1-2-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>21</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>21</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-2">

--- a/styleguide/item-1-2.html
+++ b/styleguide/item-1-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2">

--- a/styleguide/item-1-3-1.html
+++ b/styleguide/item-1-3-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-1">

--- a/styleguide/item-1-3-2.html
+++ b/styleguide/item-1-3-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>45</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>45</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-2">

--- a/styleguide/item-1-3-3.html
+++ b/styleguide/item-1-3-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>63</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>63</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-3">

--- a/styleguide/item-1-3-4.html
+++ b/styleguide/item-1-3-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>77</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>77</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-4">

--- a/styleguide/item-1-3-5.html
+++ b/styleguide/item-1-3-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>91</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>91</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-5">

--- a/styleguide/item-1-3.html
+++ b/styleguide/item-1-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>2</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>2</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3">

--- a/styleguide/item-1.html
+++ b/styleguide/item-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -362,7 +362,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1">

--- a/styleguide/item-2-1.html
+++ b/styleguide/item-2-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-1">

--- a/styleguide/item-2-2.html
+++ b/styleguide/item-2-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>18</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>18</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-2">

--- a/styleguide/item-2-3.html
+++ b/styleguide/item-2-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_row.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_row.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-3">

--- a/styleguide/item-2-4.html
+++ b/styleguide/item-2-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_column.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_column.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-4">

--- a/styleguide/item-2.html
+++ b/styleguide/item-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -266,7 +266,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_index.scss</span>, line <span>10</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_index.scss</span>, line <span>10</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2">

--- a/styleguide/item-3-1.html
+++ b/styleguide/item-3-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3-1">

--- a/styleguide/item-3.html
+++ b/styleguide/item-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -248,7 +248,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3">

--- a/styleguide/item-4-1.html
+++ b/styleguide/item-4-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-4-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>9</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>9</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-1">

--- a/styleguide/item-4-2.html
+++ b/styleguide/item-4-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-4-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>38</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-2">

--- a/styleguide/item-4-3.html
+++ b/styleguide/item-4-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-4-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>70</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>70</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-3">

--- a/styleguide/item-4.html
+++ b/styleguide/item-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -260,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4">

--- a/styleguide/item-5-1.html
+++ b/styleguide/item-5-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-5-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-1">

--- a/styleguide/item-5-2.html
+++ b/styleguide/item-5-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-5-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>30</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>30</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-2">

--- a/styleguide/item-5.html
+++ b/styleguide/item-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -254,7 +254,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5">

--- a/styleguide/item-6.html
+++ b/styleguide/item-6.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_buttons.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_buttons.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-6">

--- a/styleguide/item-7-1.html
+++ b/styleguide/item-7-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-7-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-1">

--- a/styleguide/item-7-2.html
+++ b/styleguide/item-7-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-7-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>49</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>49</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-2">

--- a/styleguide/item-7-3.html
+++ b/styleguide/item-7-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-7-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-3">

--- a/styleguide/item-7.html
+++ b/styleguide/item-7.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -260,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7">

--- a/styleguide/item-8.html
+++ b/styleguide/item-8.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_padding.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_padding.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-8">

--- a/styleguide/item-9-1.html
+++ b/styleguide/item-9-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>36</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>36</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">

--- a/styleguide/item-9.html
+++ b/styleguide/item-9.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -254,7 +254,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_links.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_links.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9">

--- a/styleguide/section-1.html
+++ b/styleguide/section-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -362,7 +362,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1">
@@ -384,7 +384,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1">
@@ -407,7 +407,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>17</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>17</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-1">
@@ -429,7 +429,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>25</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>25</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-2">
@@ -451,7 +451,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>34</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>34</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-3">
@@ -473,7 +473,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>41</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>41</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-4">
@@ -495,7 +495,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>48</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>48</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-5">
@@ -517,7 +517,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>55</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>55</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-6">
@@ -539,7 +539,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>62</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>62</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-7">
@@ -561,7 +561,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>69</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>69</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-8">
@@ -583,7 +583,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>76</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>76</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-9">
@@ -605,7 +605,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-10">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>83</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>83</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-10">
@@ -627,7 +627,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-2" id="kssref-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2">
@@ -645,7 +645,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-1">
@@ -667,7 +667,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>21</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>21</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-2">
@@ -689,7 +689,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-2" id="kssref-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>2</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>2</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3">
@@ -707,7 +707,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-1">
@@ -730,7 +730,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>45</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>45</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-2">
@@ -754,7 +754,7 @@ $unit:   String representation of the unit</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>63</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>63</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-3">
@@ -777,7 +777,7 @@ $unit:   String representation of the unit</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>77</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>77</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-4">
@@ -800,7 +800,7 @@ $unit:   String representation of the unit</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>91</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>91</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-5">

--- a/styleguide/section-2.html
+++ b/styleguide/section-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -266,7 +266,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_index.scss</span>, line <span>10</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_index.scss</span>, line <span>10</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2">
@@ -290,7 +290,7 @@ but is implemented in CSS Grid.</p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-1">
@@ -328,7 +328,7 @@ Useful for Header and Footer</p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>18</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>18</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-2">
@@ -368,7 +368,7 @@ for lg they are 8% and auto for <code>xl</code></p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_row.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_row.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-3">
@@ -406,7 +406,7 @@ Used in conjunction with the .col-* classes</p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_column.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_column.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-4">

--- a/styleguide/section-3.html
+++ b/styleguide/section-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -248,7 +248,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3">
@@ -270,7 +270,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3-1">

--- a/styleguide/section-4.html
+++ b/styleguide/section-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -260,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4">
@@ -282,7 +282,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-4-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>9</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>9</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-1">
@@ -343,7 +343,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-4-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>38</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-2">
@@ -401,7 +401,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-4-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>70</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>70</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-3">

--- a/styleguide/section-5.html
+++ b/styleguide/section-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -254,7 +254,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5">
@@ -272,7 +272,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-5-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-1">
@@ -305,7 +305,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-5-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>30</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>30</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-2">

--- a/styleguide/section-6.html
+++ b/styleguide/section-6.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_buttons.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_buttons.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-6">

--- a/styleguide/section-7.html
+++ b/styleguide/section-7.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -260,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7">
@@ -278,7 +278,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-7-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-1">
@@ -313,7 +313,7 @@ margin: 0.5rem; }</p>
         <section class="kss-section kss-section--depth-2" id="kssref-7-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>49</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>49</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-2">
@@ -337,7 +337,7 @@ require a unified margin bottom,</p>
         <section class="kss-section kss-section--depth-2" id="kssref-7-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-3">

--- a/styleguide/section-8.html
+++ b/styleguide/section-8.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -240,7 +240,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_padding.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_padding.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-8">

--- a/styleguide/section-9.html
+++ b/styleguide/section-9.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -254,7 +254,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_links.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_links.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9">
@@ -276,7 +276,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>18</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>18</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">
@@ -305,7 +305,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>36</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>36</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">


### PR DESCRIPTION
## Description
Added a note to the homepage.md file to warn customers against overriding CSS framework and Themes components with their own selectors.

When I ran `npm run build-guide`, it also added the prefix `scss/` to a bunch of the paths in the docs, and fixed some closing slashes on link elements. That's why so many files are changed for such a small addition.

## Jira Ticket
N/A

## Acceptance Criteria
- [ ] Does the warning note show up in the docs as intended?


## Test Steps
- Confirm note shows up :)

## Effect Of Changes
### Before
There wasn't a note

<img width="846" alt="Screen Shot 2020-12-08 at 11 09 27 AM" src="https://user-images.githubusercontent.com/1759866/101508716-050a7f00-3946-11eb-8360-a87a547f2cc4.png">


### After
There's a note.

<img width="856" alt="Screen Shot 2020-12-08 at 11 09 36 AM" src="https://user-images.githubusercontent.com/1759866/101508760-12c00480-3946-11eb-8502-18e40ee2e0c3.png">

## Dependencies or Side Effects
- None

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
