### PR TITLE
Block spacing updates

### DIFF
--- a/kss-config.json
+++ b/kss-config.json
@@ -3,6 +3,7 @@
   "source": [
     "scss/"
   ],
+  "homepage": "./scss/homepage.md",
   "destination": "styleguide/",
   "builder": "michelangelo/kss_styleguide/custom-template/",
   "css": [

--- a/scss/_index.scss
+++ b/scss/_index.scss
@@ -58,3 +58,4 @@ img {
 @import './links';
 @import 'components/figure_caption';
 @import 'components/chain_spacing';
+

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,7 +1,9 @@
+@import "colors";
+
 // @mixin block-margin-bottom
 //
 // For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
-// However, @mixin block-margin-bottom is a convenience mix-in to add to parent element styles for block components that
+// However, @mixin block-margin-bottom is a convenience mixin to add to parent element styles for block components that
 // require a unified margin bottom,
 //
 // Styleguide 7.3.0
@@ -18,7 +20,7 @@
 // @mixin link-color-active-hover
 //
 // Mixin to add hover and active styles to text color
-// 
+//
 // - Params:
 //   - `$color-prop`: Color to lighten (defaults to $ui-primary-font-color)
 //
@@ -51,10 +53,35 @@
   }
 }
 
-// @mixin container-vertial-spacing
-// 
-// Mixin to add vertical spaing to the elements in a container block
+// @mixin block-internal-spacing
 //
+// For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
+// However, @mixin block-internal-spacing is a convenience mixin that controls the internal spacing of items in a block
+//
+// Styleguide 7.4.0
+
+@mixin block-internal-spacing {
+  margin-bottom: map-get($spacers, 'sm');
+
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')){
+    margin-bottom: map-get($spacers, 'sm');
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+// @mixin container-vertial-spacing
+//
+// **Deprecated**<br/><br/>
+//
+// For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
+// However, @mixin container-vertial-spacing is a convenience mixin that controls the internal spacing of items in a block.<br/><br/>
+// **Deprecated due to misspelling - Please use container-vertical-spacing (see next entry)**
+//
+// Styleguide 7.5.0
+
 @mixin container-vertial-spacing {
   > * {
     margin-bottom: map-get($spacers, 'lg');
@@ -67,10 +94,36 @@
   }
 }
 
+// @mixin container-vertical-spacing
+//
+// For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
+// However, @mixin container-vertical-spacing is a convenience mixin that controls the internal spacing of items in a block.<br/><br/>
+// **Replaces the deprecated mixin container-vertial-spacing above**
+//
+// Styleguide 7.6.0
+
+@mixin container-vertical-spacing {
+  > * {
+    margin-bottom: map-get($spacers, 'lg');
+  }
+
+  @media screen and (min-width: map-get($grid-breakpoints, 'md')) {
+    > * {
+      margin-bottom: map-get($spacers, 'md');
+    }
+  }
+}
+
+// Misc
+//
+// Styleguide 10.0.0
+
 // @mixin container-hr-separator
 //
 // Mixin to add style to the HR element used as separator
 //
+// Styleguide 10.1.0
+
 @mixin container-hr-separator {
   > hr {
     background-color: $border-rule-color; // $ui-light-gray;
@@ -79,3 +132,17 @@
     margin-top: 0;
   }
 }
+
+// hr
+//
+// Styling for HR element <br /><br />
+// Same styling as @mixin container-hr-separator
+//
+// Styleguide 10.2.0
+hr {
+  background-color: $border-rule-color; // $ui-light-gray;
+  border: 0;
+  height: 1px;
+  margin-top: 0;
+}
+

--- a/scss/components/_chain_spacing.scss
+++ b/scss/components/_chain_spacing.scss
@@ -1,13 +1,11 @@
 .chain-container {
   .chain-col {
-    @include container-vertial-spacing;
-    @include container-hr-separator;
+    @include container-vertical-spacing;
   }
 }
 
 .layout-section {
-  @include container-vertial-spacing;
-  @include container-hr-separator;
+  @include container-vertical-spacing;
 }
 
 // Used to remove the extra margin on layouts when the class

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -61,3 +61,4 @@ img {
 @import './links';
 @import 'components/figure_caption';
 @import 'components/chain_spacing';
+

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -222,6 +222,12 @@
           <a class="" href="section-9.html">
             <span class="kss-nav__ref">9</span>
             <span class="kss-nav__name">Links</span>
+          </a>
+        </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
           </a>
         </li>
       </ul>

--- a/styleguide/item-1-1-1.html
+++ b/styleguide/item-1-1-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>17</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>17</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-1">

--- a/styleguide/item-1-1-10.html
+++ b/styleguide/item-1-1-10.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-10">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>83</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>83</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-10">

--- a/styleguide/item-1-1-2.html
+++ b/styleguide/item-1-1-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>25</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>25</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-2">

--- a/styleguide/item-1-1-3.html
+++ b/styleguide/item-1-1-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>34</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>34</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-3">

--- a/styleguide/item-1-1-4.html
+++ b/styleguide/item-1-1-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>41</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>41</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-4">

--- a/styleguide/item-1-1-5.html
+++ b/styleguide/item-1-1-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>48</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>48</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-5">

--- a/styleguide/item-1-1-6.html
+++ b/styleguide/item-1-1-6.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>55</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>55</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-6">

--- a/styleguide/item-1-1-7.html
+++ b/styleguide/item-1-1-7.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>62</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>62</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-7">

--- a/styleguide/item-1-1-8.html
+++ b/styleguide/item-1-1-8.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>69</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>69</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-8">

--- a/styleguide/item-1-1-9.html
+++ b/styleguide/item-1-1-9.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-1-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>76</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>76</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-9">

--- a/styleguide/item-1-1.html
+++ b/styleguide/item-1-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1">

--- a/styleguide/item-1-2-1.html
+++ b/styleguide/item-1-2-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-1">

--- a/styleguide/item-1-2-2.html
+++ b/styleguide/item-1-2-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>21</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>21</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-2">

--- a/styleguide/item-1-2.html
+++ b/styleguide/item-1-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2">

--- a/styleguide/item-1-3-1.html
+++ b/styleguide/item-1-3-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-1">

--- a/styleguide/item-1-3-2.html
+++ b/styleguide/item-1-3-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>45</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>45</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-2">

--- a/styleguide/item-1-3-3.html
+++ b/styleguide/item-1-3-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>63</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>63</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-3">

--- a/styleguide/item-1-3-4.html
+++ b/styleguide/item-1-3-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>77</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>77</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-4">

--- a/styleguide/item-1-3-5.html
+++ b/styleguide/item-1-3-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-3" id="kssref-1-3-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>91</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>91</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-5">

--- a/styleguide/item-1-3.html
+++ b/styleguide/item-1-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>2</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>2</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3">

--- a/styleguide/item-1.html
+++ b/styleguide/item-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -346,6 +346,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -362,7 +368,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1">

--- a/styleguide/item-2-1.html
+++ b/styleguide/item-2-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-1">

--- a/styleguide/item-2-2.html
+++ b/styleguide/item-2-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>18</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>18</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-2">

--- a/styleguide/item-2-3.html
+++ b/styleguide/item-2-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_row.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_row.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-3">

--- a/styleguide/item-2-4.html
+++ b/styleguide/item-2-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-2-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_column.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_column.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-4">

--- a/styleguide/item-2.html
+++ b/styleguide/item-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -250,6 +250,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -266,7 +272,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_index.scss</span>, line <span>10</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_index.scss</span>, line <span>10</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2">

--- a/styleguide/item-3-1.html
+++ b/styleguide/item-3-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3-1">

--- a/styleguide/item-3.html
+++ b/styleguide/item-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -232,6 +232,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -248,7 +254,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3">

--- a/styleguide/item-4-1.html
+++ b/styleguide/item-4-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-4-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>9</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>9</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-1">

--- a/styleguide/item-4-2.html
+++ b/styleguide/item-4-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-4-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>38</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-2">

--- a/styleguide/item-4-3.html
+++ b/styleguide/item-4-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-4-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>70</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>70</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-3">

--- a/styleguide/item-4.html
+++ b/styleguide/item-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -244,6 +244,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -260,7 +266,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4">

--- a/styleguide/item-5-1.html
+++ b/styleguide/item-5-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-5-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-1">

--- a/styleguide/item-5-2.html
+++ b/styleguide/item-5-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-5-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>30</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>30</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-2">

--- a/styleguide/item-5.html
+++ b/styleguide/item-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -238,6 +238,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -254,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5">

--- a/styleguide/item-6.html
+++ b/styleguide/item-6.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_buttons.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_buttons.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-6">

--- a/styleguide/item-7-1.html
+++ b/styleguide/item-7-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-7-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-1">

--- a/styleguide/item-7-2.html
+++ b/styleguide/item-7-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-7-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>49</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>49</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-2">

--- a/styleguide/item-7-3.html
+++ b/styleguide/item-7-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-7-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>3</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-3">
@@ -253,7 +259,7 @@
             <div
               class="kss-section__description">
               <p>For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
-However, @mixin block-margin-bottom is a convenience mix-in to add to parent element styles for block components that
+However, @mixin block-margin-bottom is a convenience mixin to add to parent element styles for block components that
 require a unified margin bottom,</p>
 </div>
 

--- a/styleguide/item-7.html
+++ b/styleguide/item-7.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -230,6 +230,24 @@
                 <span class="kss-nav__name">@mixin block-margin-bottom</span>
               </a>
             </li>
+            <li class="kss-nav__item ">
+              <a href="section-7.html#kssref-7-4">
+                <span class="kss-nav__ref">7.4</span>
+                <span class="kss-nav__name">@mixin block-internal-spacing</span>
+              </a>
+            </li>
+            <li class="kss-nav__item ">
+              <a href="section-7.html#kssref-7-5">
+                <span class="kss-nav__ref">7.5</span>
+                <span class="kss-nav__name">@mixin container-vertial-spacing</span>
+              </a>
+            </li>
+            <li class="kss-nav__item ">
+              <a href="section-7.html#kssref-7-6">
+                <span class="kss-nav__ref">7.6</span>
+                <span class="kss-nav__name">@mixin container-vertical-spacing</span>
+              </a>
+            </li>
           </ul>
         </li>
         <li class="kss-nav__item">
@@ -242,6 +260,12 @@
           <a class="" href="section-9.html">
             <span class="kss-nav__ref">9</span>
             <span class="kss-nav__name">Links</span>
+          </a>
+        </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
           </a>
         </li>
       </ul>
@@ -260,7 +284,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7">

--- a/styleguide/item-8.html
+++ b/styleguide/item-8.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_padding.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_padding.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-8">

--- a/styleguide/item-9-1.html
+++ b/styleguide/item-9-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>36</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">

--- a/styleguide/item-9.html
+++ b/styleguide/item-9.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -238,6 +238,12 @@
             </li>
           </ul>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -254,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_links.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_links.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9">

--- a/styleguide/section-1.html
+++ b/styleguide/section-1.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -346,6 +346,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -362,7 +368,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1">
@@ -384,7 +390,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1">
@@ -407,7 +413,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>17</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>17</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-1">
@@ -429,7 +435,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>25</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>25</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-2">
@@ -451,7 +457,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>34</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>34</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-3">
@@ -473,7 +479,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>41</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>41</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-4">
@@ -495,7 +501,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>48</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>48</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-5">
@@ -517,7 +523,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>55</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>55</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-6">
@@ -539,7 +545,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>62</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>62</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-7">
@@ -561,7 +567,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>69</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>69</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-8">
@@ -583,7 +589,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>76</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>76</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-9">
@@ -605,7 +611,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-1-10">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_variables.scss</span>, line <span>83</span>
+            <p class="kss-section__source">Source: <span>scss/_variables.scss</span>, line <span>83</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-1-10">
@@ -627,7 +633,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-2" id="kssref-1-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2">
@@ -645,7 +651,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-1">
@@ -667,7 +673,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_breakpoints.scss</span>, line <span>21</span>
+            <p class="kss-section__source">Source: <span>scss/_breakpoints.scss</span>, line <span>21</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-2-2">
@@ -689,7 +695,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-2" id="kssref-1-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>2</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>2</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3">
@@ -707,7 +713,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-1">
@@ -730,7 +736,7 @@ the code base DRY.</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>45</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>45</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-2">
@@ -754,7 +760,7 @@ $unit:   String representation of the unit</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>63</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>63</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-3">
@@ -777,7 +783,7 @@ $unit:   String representation of the unit</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>77</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>77</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-4">
@@ -800,7 +806,7 @@ $unit:   String representation of the unit</p>
         <section class="kss-section kss-section--depth-3" id="kssref-1-3-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_functions.scss</span>, line <span>91</span>
+            <p class="kss-section__source">Source: <span>scss/_functions.scss</span>, line <span>91</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-1-3-5">

--- a/styleguide/section-2.html
+++ b/styleguide/section-2.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -250,6 +250,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -266,7 +272,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_index.scss</span>, line <span>10</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_index.scss</span>, line <span>10</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2">
@@ -290,7 +296,7 @@ but is implemented in CSS Grid.</p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-1">
@@ -328,7 +334,7 @@ Useful for Header and Footer</p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_containers.scss</span>, line <span>18</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_containers.scss</span>, line <span>18</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-2">
@@ -368,7 +374,7 @@ for lg they are 8% and auto for <code>xl</code></p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_row.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_row.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-3">
@@ -406,7 +412,7 @@ Used in conjunction with the .col-* classes</p>
         <section class="kss-section kss-section--depth-2" id="kssref-2-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>grid/_grid_column.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/grid/_grid_column.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-2-4">

--- a/styleguide/section-3.html
+++ b/styleguide/section-3.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -232,6 +232,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -248,7 +254,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3">
@@ -270,7 +276,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-3-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_colors.scss</span>, line <span>8</span>
+            <p class="kss-section__source">Source: <span>scss/_colors.scss</span>, line <span>8</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-3-1">

--- a/styleguide/section-4.html
+++ b/styleguide/section-4.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -244,6 +244,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -260,7 +266,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-4">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4">
@@ -282,7 +288,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-4-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>9</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>9</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-1">
@@ -343,7 +349,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-4-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>38</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-2">
@@ -401,7 +407,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-4-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>utils/_utils.scss</span>, line <span>70</span>
+            <p class="kss-section__source">Source: <span>scss/utils/_utils.scss</span>, line <span>70</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-4-3">

--- a/styleguide/section-5.html
+++ b/styleguide/section-5.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -238,6 +238,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -254,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-5">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5">
@@ -272,7 +278,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-5-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>7</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-1">
@@ -305,7 +311,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-5-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>typography/_index.scss</span>, line <span>30</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>30</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-2">

--- a/styleguide/section-6.html
+++ b/styleguide/section-6.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-6">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_buttons.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_buttons.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-6">

--- a/styleguide/section-7.html
+++ b/styleguide/section-7.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -230,6 +230,24 @@
                 <span class="kss-nav__name">@mixin block-margin-bottom</span>
               </a>
             </li>
+            <li class="kss-nav__item ">
+              <a href="section-7.html#kssref-7-4">
+                <span class="kss-nav__ref">7.4</span>
+                <span class="kss-nav__name">@mixin block-internal-spacing</span>
+              </a>
+            </li>
+            <li class="kss-nav__item ">
+              <a href="section-7.html#kssref-7-5">
+                <span class="kss-nav__ref">7.5</span>
+                <span class="kss-nav__name">@mixin container-vertial-spacing</span>
+              </a>
+            </li>
+            <li class="kss-nav__item ">
+              <a href="section-7.html#kssref-7-6">
+                <span class="kss-nav__ref">7.6</span>
+                <span class="kss-nav__name">@mixin container-vertical-spacing</span>
+              </a>
+            </li>
           </ul>
         </li>
         <li class="kss-nav__item">
@@ -242,6 +260,12 @@
           <a class="" href="section-9.html">
             <span class="kss-nav__ref">9</span>
             <span class="kss-nav__name">Links</span>
+          </a>
+        </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
           </a>
         </li>
       </ul>
@@ -260,7 +284,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-7">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7">
@@ -278,7 +302,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-7-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>6</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>6</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-1">
@@ -313,7 +337,7 @@ margin: 0.5rem; }</p>
         <section class="kss-section kss-section--depth-2" id="kssref-7-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_margins.scss</span>, line <span>49</span>
+            <p class="kss-section__source">Source: <span>scss/_margins.scss</span>, line <span>49</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-2">
@@ -337,7 +361,7 @@ require a unified margin bottom,</p>
         <section class="kss-section kss-section--depth-2" id="kssref-7-3">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>3</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-7-3">
@@ -350,8 +374,80 @@ require a unified margin bottom,</p>
             <div
               class="kss-section__description">
               <p>For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
-However, @mixin block-margin-bottom is a convenience mix-in to add to parent element styles for block components that
+However, @mixin block-margin-bottom is a convenience mixin to add to parent element styles for block components that
 require a unified margin bottom,</p>
+</div>
+
+          </article>
+
+
+    </section>
+        <section class="kss-section kss-section--depth-2" id="kssref-7-4">
+
+          <article class="kss-section__content">
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>56</span>
+            </p>
+
+            <a class="kss-section__permalink" href="#kssref-7-4">
+              <h2 class="kss-section__item kss-section__item--depth-2">
+                <span class="kss-section__ref">7.4</span>
+                <span class="kss-section__name">@mixin block-internal-spacing</span>
+              </h2>
+            </a>
+
+            <div
+              class="kss-section__description">
+              <p>For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
+However, @mixin block-internal-spacing is a convenience mixin that controls the internal spacing of items in a block</p>
+</div>
+
+          </article>
+
+
+    </section>
+        <section class="kss-section kss-section--depth-2" id="kssref-7-5">
+
+          <article class="kss-section__content">
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>75</span>
+            </p>
+
+            <a class="kss-section__permalink" href="#kssref-7-5">
+              <h2 class="kss-section__item kss-section__item--depth-2">
+                <span class="kss-section__ref">7.5</span>
+                <span class="kss-section__name">@mixin container-vertial-spacing</span>
+              </h2>
+            </a>
+
+            <div
+              class="kss-section__description">
+              <p><strong>Deprecated</strong><br/><br/></p>
+<p>For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
+However, @mixin container-vertial-spacing is a convenience mixin that controls the internal spacing of items in a block.<br/><br/>
+<strong>Deprecated due to misspelling - Please use container-vertical-spacing (see next entry)</strong></p>
+</div>
+
+          </article>
+
+
+    </section>
+        <section class="kss-section kss-section--depth-2" id="kssref-7-6">
+
+          <article class="kss-section__content">
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>97</span>
+            </p>
+
+            <a class="kss-section__permalink" href="#kssref-7-6">
+              <h2 class="kss-section__item kss-section__item--depth-2">
+                <span class="kss-section__ref">7.6</span>
+                <span class="kss-section__name">@mixin container-vertical-spacing</span>
+              </h2>
+            </a>
+
+            <div
+              class="kss-section__description">
+              <p>For most purposes, margins should be retrieved from $spacers (using map-get) in _breakpoints.scss
+However, @mixin container-vertical-spacing is a convenience mixin that controls the internal spacing of items in a block.<br/><br/>
+<strong>Replaces the deprecated mixin container-vertial-spacing above</strong></p>
 </div>
 
           </article>

--- a/styleguide/section-8.html
+++ b/styleguide/section-8.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -224,6 +224,12 @@
             <span class="kss-nav__name">Links</span>
           </a>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -240,7 +246,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-8">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_padding.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_padding.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-8">

--- a/styleguide/section-9.html
+++ b/styleguide/section-9.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="kss-assets/css/kss.css">
   <link rel="stylesheet" href="https://nav-prod.home.static.arcpublishing.com/css/arcnav.css">
   <script src="https://nav-prod.home.static.arcpublishing.com/js/arcnav-standalone.js" async></script>
-  <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/index.css"/>
 
 
   <style>
@@ -238,6 +238,12 @@
             </li>
           </ul>
         </li>
+        <li class="kss-nav__item">
+          <a class="" href="section-10.html">
+            <span class="kss-nav__ref">10</span>
+            <span class="kss-nav__name">Misc</span>
+          </a>
+        </li>
       </ul>
     </section>
     <!-- /navigation. -->
@@ -254,7 +260,7 @@
       <header class="kss-section kss-section--depth-1" id="kssref-9">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_links.scss</span>, line <span>1</span>
+            <p class="kss-section__source">Source: <span>scss/_links.scss</span>, line <span>1</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9">
@@ -276,7 +282,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>18</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>20</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">
@@ -305,7 +311,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>_mixins.scss</span>, line <span>36</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">


### PR DESCRIPTION
## Description
This ticket represents the design changes Brandon requested in his PR:  https://github.com/WPMedia/news-theme-css/pull/46.  However, I have kept old classes and mixins but deprecating them. Documentation has been updated as well that included if an entity has been deprecated.

This PR accompanies a PR from the fusion-news-theme-blocks:  https://github.com/WPMedia/fusion-news-theme-blocks/pull/639

## Jira Ticket
- https://arcpublishing.atlassian.net/browse/PEN-1475

## Acceptance Criteria
@brandonhunty will need to verify.  Right now there will be an associated PR for fusion-news-theme-blocks however I am unable to push it as there is an issue with the test library.


## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [x ] Confirmed all the test steps above are working
- [x ] Confirmed there are no linter errors
- [x ] Confirmed this PR has reasonable code coverage
  - [x ] Confirmed this PR has unit test files
  - [x ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ x] Confirmed relevant documentation has been updated/added.
