### PR TITLE
Reset all margin's on hr element

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -135,7 +135,7 @@
 
 // hr
 //
-// Styling for HR element <br /><br />
+// Styling for HR element <hr /><br /><hr />
 // Same styling as @mixin container-hr-separator
 //
 // Styleguide 10.2.0

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -129,7 +129,7 @@
     background-color: $border-rule-color; // $ui-light-gray;
     border: 0;
     height: 1px;
-    margin-top: 0;
+    margin: 0;
   }
 }
 
@@ -143,6 +143,5 @@ hr {
   background-color: $border-rule-color; // $ui-light-gray;
   border: 0;
   height: 1px;
-  margin-top: 0;
+  margin: 0;
 }
-

--- a/styleguide/item-9-1.html
+++ b/styleguide/item-9-1.html
@@ -246,25 +246,22 @@
       <header class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>20</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>38</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">
               <h2 class="kss-section__item kss-section__item--depth-2">
                 <span class="kss-section__ref">9.1</span>
-                <span class="kss-section__name">@mixin link-color-active-hover</span>
+                <span class="kss-section__name">@mixin svg-color-active-hover</span>
               </h2>
             </a>
 
             <div
               class="kss-section__description">
-              <p>Mixin to add hover and active styles to text color</p>
+              <p>Mixin to add hover and active styles to svg fill</p>
 <ul>
-<li>Params:
-<ul>
+<li>Params:</li>
 <li><code>$color-prop</code>: Color to lighten (defaults to $ui-primary-font-color)</li>
-</ul>
-</li>
 </ul>
 </div>
 
@@ -285,5 +282,7 @@
     <!-- /scripts. -->
   </div>
 </body>
+
+</html>/body>
 
 </html>

--- a/styleguide/item-9-1.html
+++ b/styleguide/item-9-1.html
@@ -246,22 +246,25 @@
       <header class="kss-section kss-section--depth-2" id="kssref-9-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>38</span>
+            <p class="kss-section__source">Source: <span>scss/_mixins.scss</span>, line <span>20</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-9-1">
               <h2 class="kss-section__item kss-section__item--depth-2">
                 <span class="kss-section__ref">9.1</span>
-                <span class="kss-section__name">@mixin svg-color-active-hover</span>
+                <span class="kss-section__name">@mixin link-color-active-hover</span>
               </h2>
             </a>
 
             <div
               class="kss-section__description">
-              <p>Mixin to add hover and active styles to svg fill</p>
+              <p>Mixin to add hover and active styles to text color</p>
 <ul>
-<li>Params:</li>
+<li>Params:
+<ul>
 <li><code>$color-prop</code>: Color to lighten (defaults to $ui-primary-font-color)</li>
+</ul>
+</li>
 </ul>
 </div>
 
@@ -282,7 +285,5 @@
     <!-- /scripts. -->
   </div>
 </body>
-
-</html>/body>
 
 </html>


### PR DESCRIPTION
## Description

Reset all margins on the `hr` element to allow layout components to have better control of child nodes. As only the top margin was being set to 0 the default browser margin value was being used and causes unexpected layout gaps which then require each component to have to reset the `hr` margins manually

## Jira Ticket
- [TMEDIA-108](https://arcpublishing.atlassian.net/browse/TMEDIA-108)

## Dependencies or Side Effects
_Examples of dependencies or side effects are:_
- Additional settings that will be required in the blocks.json
- Changes to the custom fields which will require users to reconfigure features
- Update to css framework or SDK
- Dependency on another PR that needs to be merged first

## Review Checklist
_The author of the PR should fill out the following sections to ensure this PR is ready for review._
- [ ] Confirmed all the test steps above are working
- [ ] Confirmed there are no linter errors
- [ ] Confirmed this PR has reasonable code coverage
  - [ ] Confirmed this PR has unit test files
  - [ ] Ran `npm test`, made sure all tests are passing
  - [ ] If the amount of work to write unit tests for this change are excessive,
please explain why (so that we can fix it whenever it gets refactored).
- [ ] Confirmed relevant documentation has been updated/added.
