### PR TITLE
TMEDIA 182: Clarify override docs 

### DIFF
--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -1,6 +1,6 @@
 // Colors
 //
-// Colors have the option to be overriden in the `blocks.json` file
+// The primary color can be overridden per website using the [Theme Setting](https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/) `primary-color`.
 //
 // Styleguide 3.0.0
 

--- a/scss/typography/_index.scss
+++ b/scss/typography/_index.scss
@@ -1,4 +1,6 @@
 // Typography
+// 
+// The primary and secondary font families can be overridden per website using the [Theme Settings](https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/) `primary-font-family` and `secondary-font-family`, respectively.
 //
 // Styleguide 5.0.0
 

--- a/styleguide/item-3.html
+++ b/styleguide/item-3.html
@@ -266,7 +266,7 @@
 
             <div
               class="kss-section__description">
-              <p>Colors have the option to be overriden in the <code>blocks.json</code> file</p>
+              <p>The primary color can be overridden per website using the <a href="https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/">Theme Setting</a> <code>primary-color</code>.</p>
 </div>
 
           </article>

--- a/styleguide/item-5-1.html
+++ b/styleguide/item-5-1.html
@@ -246,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-5-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>9</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-1">

--- a/styleguide/item-5-2.html
+++ b/styleguide/item-5-2.html
@@ -246,7 +246,7 @@
       <header class="kss-section kss-section--depth-2" id="kssref-5-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>30</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>32</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-2">

--- a/styleguide/item-5.html
+++ b/styleguide/item-5.html
@@ -270,6 +270,10 @@
               </h1>
             </a>
 
+            <div
+              class="kss-section__description">
+              <p>The primary and secondary font families can be overridden per website using the <a href="https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/">Theme Settings</a> <code>primary-font-family</code> and <code>secondary-font-family</code>, respectively.</p>
+</div>
 
           </article>
 

--- a/styleguide/section-3.html
+++ b/styleguide/section-3.html
@@ -266,7 +266,7 @@
 
             <div
               class="kss-section__description">
-              <p>Colors have the option to be overriden in the <code>blocks.json</code> file</p>
+              <p>The primary color can be overridden per website using the <a href="https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/">Theme Setting</a> <code>primary-color</code>.</p>
 </div>
 
           </article>

--- a/styleguide/section-5.html
+++ b/styleguide/section-5.html
@@ -270,6 +270,10 @@
               </h1>
             </a>
 
+            <div
+              class="kss-section__description">
+              <p>The primary and secondary font families can be overridden per website using the <a href="https://redirector.arcpublishing.com/alc/arc-products/themes/user-docs/theme-settings/">Theme Settings</a> <code>primary-font-family</code> and <code>secondary-font-family</code>, respectively.</p>
+</div>
 
           </article>
 
@@ -278,7 +282,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-5-1">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>7</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>9</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-1">
@@ -311,7 +315,7 @@
         <section class="kss-section kss-section--depth-2" id="kssref-5-2">
 
           <article class="kss-section__content">
-            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>30</span>
+            <p class="kss-section__source">Source: <span>scss/typography/_index.scss</span>, line <span>32</span>
             </p>
 
             <a class="kss-section__permalink" href="#kssref-5-2">


### PR DESCRIPTION
docs: Update override settings documentation to be more specific 
- ran npm run build-guide to generate the styleguide

<img width="1367" alt="Screen Shot 2021-04-29 at 09 13 01" src="https://user-images.githubusercontent.com/5950956/116565778-c7de6380-a8cb-11eb-914c-1cbf3a26a33d.png">
<img width="1284" alt="Screen Shot 2021-04-29 at 09 12 48" src="https://user-images.githubusercontent.com/5950956/116565787-c90f9080-a8cb-11eb-867b-63eb780c1ea4.png">

